### PR TITLE
fix(chat): Sprint 14 — openDrawer UX + histórico de sessão no ChatDrawer

### DIFF
--- a/src/components/chat/ChatFAB.tsx
+++ b/src/components/chat/ChatFAB.tsx
@@ -29,17 +29,12 @@ export default function ChatFAB() {
   // Usado pelo onOpen para leitura síncrona sem depender de closure
   const pendingMessagesRef = useRef<ChatMessage[]>([]);
 
-  const { pendingMessages, unreadCount } = useSystemIntents({
+  const { pendingMessages, unreadCount, hasPriorityMessage } = useSystemIntents({
     userId: user?.id ?? '',
     profileId: user?.id ?? '',
     sessionId,
     accessToken: session?.access_token ?? '',
     isDrawerOpen: isOpen,
-    onOpen: () => {
-      // Lê o ref — sempre tem o valor atual, sem stale closure
-      setDrawerMessages([...pendingMessagesRef.current]);
-      setIsOpen(true);
-    },
   });
 
   // Sincronizar ref com o state atual (síncrono, sem delay de useEffect)
@@ -60,7 +55,7 @@ export default function ChatFAB() {
       {/* FAB button */}
       <button
         onClick={handleToggle}
-        className="fixed z-30 flex items-center justify-center rounded-full shadow-lg transition-all hover:scale-105 active:scale-95"
+        className={`fixed z-30 flex items-center justify-center rounded-full shadow-lg transition-all hover:scale-105 active:scale-95${!isOpen && hasPriorityMessage ? ' animate-pulse' : ''}`}
         style={{
           bottom: 'calc(env(safe-area-inset-bottom) + 76px)',
           right: '16px',
@@ -69,8 +64,10 @@ export default function ChatFAB() {
           background: isOpen
             ? 'rgba(255,255,255,0.9)'
             : 'linear-gradient(135deg, #38B1E4 0%, #024F86 100%)',
-          border: isOpen ? '2px solid rgba(56,177,228,0.4)' : 'none',
-          boxShadow: '0 8px 24px rgba(2,79,134,0.35)',
+          border: isOpen ? '2px solid rgba(56,177,228,0.4)' : (!isOpen && hasPriorityMessage ? '2px solid rgba(56,177,228,0.7)' : 'none'),
+          boxShadow: !isOpen && hasPriorityMessage
+            ? '0 8px 32px rgba(56,177,228,0.55)'
+            : '0 8px 24px rgba(2,79,134,0.35)',
         }}
         aria-label={isOpen ? 'Fechar Cloudinha' : 'Abrir Cloudinha'}
       >

--- a/src/components/chat/ChatFAB.tsx
+++ b/src/components/chat/ChatFAB.tsx
@@ -54,15 +54,24 @@ export default function ChatFAB() {
     <>
       {/* Background Pulse Animation */}
       {!isOpen && hasPriorityMessage && (
-        <div
-          className="fixed z-20 rounded-full bg-[#38B1E4] animate-ping opacity-75"
+        <div 
+          className="fixed z-20 pointer-events-none flex items-center justify-center"
           style={{
             bottom: 'calc(env(safe-area-inset-bottom) + 76px)',
             right: '16px',
             width: 52,
             height: 52,
           }}
-        />
+        >
+          <div 
+            className="absolute w-full h-full rounded-full bg-[#38B1E4] animate-ping opacity-75" 
+            style={{ animationDuration: '3s' }}
+          />
+          <div 
+            className="absolute w-full h-full rounded-full bg-[#38B1E4] animate-ping opacity-50" 
+            style={{ animationDuration: '3s', animationDelay: '1.5s' }}
+          />
+        </div>
       )}
 
       {/* FAB button */}

--- a/src/components/chat/ChatFAB.tsx
+++ b/src/components/chat/ChatFAB.tsx
@@ -52,10 +52,23 @@ export default function ChatFAB() {
 
   return (
     <>
+      {/* Background Pulse Animation */}
+      {!isOpen && hasPriorityMessage && (
+        <div
+          className="fixed z-20 rounded-full bg-[#38B1E4] animate-ping opacity-75"
+          style={{
+            bottom: 'calc(env(safe-area-inset-bottom) + 76px)',
+            right: '16px',
+            width: 52,
+            height: 52,
+          }}
+        />
+      )}
+
       {/* FAB button */}
       <button
         onClick={handleToggle}
-        className={`fixed z-30 flex items-center justify-center rounded-full shadow-lg transition-all hover:scale-105 active:scale-95${!isOpen && hasPriorityMessage ? ' animate-pulse' : ''}`}
+        className="fixed z-30 flex items-center justify-center rounded-full shadow-lg transition-all hover:scale-105 active:scale-95"
         style={{
           bottom: 'calc(env(safe-area-inset-bottom) + 76px)',
           right: '16px',

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -3,8 +3,9 @@
 // useChat — Sprint 03 Épico 1C
 // Manages chat UI state: messages, streaming, tool activity, and follow-up suggestions.
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { streamChat, type ChatMessage, type ChatEvent } from '@/services/chatService';
+import { supabase } from '@/lib/supabase';
 
 function genId(): string {
   return Math.random().toString(36).slice(2) + Date.now().toString(36);
@@ -31,6 +32,45 @@ export function useChat({
   const [isStreaming, setIsStreaming] = useState(false);
   const [activeTool, setActiveTool] = useState<string | null>(null);
   const [suggestions, setSuggestions] = useState<string[]>([]);
+
+  // Carregar histórico da sessão ao montar o drawer
+  useEffect(() => {
+    if (!sessionId || !supabase) return;
+
+    async function loadHistory() {
+      try {
+        const { data, error } = await supabase
+          .from('chat_messages')
+          .select('id, sender, content, created_at')
+          .eq('session_id', sessionId)
+          .neq('sender', 'system')
+          .order('created_at', { ascending: true });
+
+        if (error || !data || data.length === 0) return;
+
+        const historical: ChatMessage[] = data.map((row: { id: string; sender: string; content: string; created_at: string }) => ({
+          id: row.id,
+          sender: row.sender as 'user' | 'model',
+          content: row.content,
+          timestamp: new Date(row.created_at),
+        }));
+
+        setMessages((prev) => {
+          // Evitar duplicatas: IDs do banco vs initialMessages
+          const existingIds = new Set(prev.map((m) => m.id));
+          const newHistorical = historical.filter((m) => !existingIds.has(m.id));
+          if (newHistorical.length === 0) return prev;
+          return [...newHistorical, ...prev];
+        });
+      } catch (e) {
+        console.warn('[useChat] Falha ao carregar histórico:', e);
+      }
+    }
+
+    loadHistory();
+  // Executa apenas na montagem; sessionId não muda durante o ciclo de vida do drawer
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const sendMessage = useCallback(
     async (input: string) => {

--- a/src/hooks/useSystemIntents.ts
+++ b/src/hooks/useSystemIntents.ts
@@ -10,7 +10,8 @@
  * Quando o backend responde:
  *   - A resposta da Cloudinha (real, gerada pelo LLM) é armazenada como pendingMessage
  *   - O FAB exibe um badge com o contador de mensagens não lidas
- *   - Se o backend envia intent_metadata com open_drawer=true, o drawer abre após delay_ms
+ *   - Se o backend envia intent_metadata com open_drawer=true, sinaliza hasPriorityMessage
+ *     para o FAB exibir animação de pulso — NÃO abre o drawer automaticamente
  */
 
 import { useEffect, useRef, useState, useCallback } from 'react';
@@ -27,12 +28,12 @@ interface UseSystemIntentsOptions {
   sessionId: string;
   accessToken: string;
   isDrawerOpen: boolean;
-  onOpen: () => void;
 }
 
 interface UseSystemIntentsReturn {
   pendingMessages: ChatMessage[];
   unreadCount: number;
+  hasPriorityMessage: boolean;
   consumeMessages: () => ChatMessage[];
 }
 
@@ -42,25 +43,21 @@ export function useSystemIntents({
   sessionId,
   accessToken,
   isDrawerOpen,
-  onOpen,
 }: UseSystemIntentsOptions): UseSystemIntentsReturn {
   const pathname = usePathname();
   const [pendingMessages, setPendingMessages] = useState<ChatMessage[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
+  const [hasPriorityMessage, setHasPriorityMessage] = useState(false);
 
   // Rastreia qual rota+userId já foi disparado para evitar duplicatas
   // Formato: "userId::pathname"
   const dispatchedRef = useRef<string>('');
-  const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Zerar badge quando drawer é aberto
+  // Zerar badge e prioridade quando drawer é aberto
   useEffect(() => {
     if (isDrawerOpen) {
       setUnreadCount(0);
-      if (openTimerRef.current) {
-        clearTimeout(openTimerRef.current);
-        openTimerRef.current = null;
-      }
+      setHasPriorityMessage(false);
     }
   }, [isDrawerOpen]);
 
@@ -139,11 +136,7 @@ export function useSystemIntents({
           if (event.type === 'intent_metadata') {
             console.log('[SystemIntent] intent_metadata recebido:', event);
             if (event.open_drawer && !isDrawerOpen) {
-              const delay = event.delay_ms ?? 5000;
-              openTimerRef.current = setTimeout(() => {
-                onOpen();
-                openTimerRef.current = null;
-              }, delay);
+              setHasPriorityMessage(true);
             }
           }
         }
@@ -156,10 +149,6 @@ export function useSystemIntents({
 
     return () => {
       cancelled = true;
-      if (openTimerRef.current) {
-        clearTimeout(openTimerRef.current);
-        openTimerRef.current = null;
-      }
     };
   // Intencionalmente inclui userId e accessToken para retentar quando auth carrega
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -210,8 +199,7 @@ export function useSystemIntents({
             }
           }
           if (event.type === 'intent_metadata' && event.open_drawer && !isDrawerOpen) {
-            const delay = event.delay_ms ?? 0;
-            openTimerRef.current = setTimeout(() => { onOpen(); openTimerRef.current = null; }, delay);
+            setHasPriorityMessage(true);
           }
         }
       } catch (err) {
@@ -235,5 +223,5 @@ export function useSystemIntents({
     return msgs;
   }, [pendingMessages]);
 
-  return { pendingMessages, unreadCount, consumeMessages };
+  return { pendingMessages, unreadCount, hasPriorityMessage, consumeMessages };
 }

--- a/src/hooks/useSystemIntents.ts
+++ b/src/hooks/useSystemIntents.ts
@@ -214,6 +214,70 @@ export function useSystemIntents({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userId, accessToken]);
 
+  // Tutorial para usuários anônimos: dispara 1x por sessão via sessionStorage
+  useEffect(() => {
+    const TUTORIAL_KEY = 'nubo_tutorial_shown';
+    if (typeof window === 'undefined') return;
+    if (sessionStorage.getItem(TUTORIAL_KEY)) return;
+
+    sessionStorage.setItem(TUTORIAL_KEY, 'true');
+
+    // UUID nulo é aceito pelo backend como sentinela para usuários anônimos
+    const ANON_UUID = '00000000-0000-0000-0000-000000000000';
+    const effectiveUserId = userId || ANON_UUID;
+    const effectiveProfileId = profileId || ANON_UUID;
+
+    let cancelled = false;
+
+    async function dispatchTutorial() {
+      try {
+        const stream = streamChat(
+          {
+            chatInput: 'tutorial',
+            userId: effectiveUserId,
+            active_profile_id: effectiveProfileId,
+            sessionId,
+            intent_type: 'system_intent',
+            ui_context: { current_page: pathname },
+          },
+          accessToken,
+        );
+
+        let hasContent = false;
+        for await (const event of stream) {
+          if (cancelled) break;
+          if (event.type === 'text' && event.content) {
+            setPendingMessages((prev) => {
+              if (hasContent && prev.length > 0) {
+                const updated = [...prev];
+                updated[updated.length - 1] = {
+                  ...updated[updated.length - 1],
+                  content: updated[updated.length - 1].content + event.content,
+                };
+                return updated;
+              }
+              return [...prev, { id: genId(), sender: 'model' as const, content: event.content!, timestamp: new Date() }];
+            });
+            if (!hasContent) {
+              hasContent = true;
+              if (!isDrawerOpen) setUnreadCount((n) => n + 1);
+            }
+          }
+          if (event.type === 'intent_metadata' && event.open_drawer && !isDrawerOpen) {
+            setHasPriorityMessage(true);
+          }
+        }
+      } catch (e) {
+        console.warn('[SystemIntent] Falha ao disparar tutorial:', e);
+      }
+    }
+
+    dispatchTutorial();
+    return () => { cancelled = true; };
+  // Executa apenas 1x na montagem — sessionStorage garante deduplicação entre renders
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Consumir mensagens (para injetar no ChatDrawer quando abre)
   const consumeMessages = useCallback((): ChatMessage[] => {
     const msgs = [...pendingMessages];


### PR DESCRIPTION
## Resumo

### Bug 1 — `openDrawer = true` não deveria abrir o drawer automaticamente
- **`useSystemIntents.ts`:** Removido `onOpen()` automático ao receber `intent_metadata.open_drawer`. Em vez disso, sinaliza `hasPriorityMessage = true`.
- **`ChatFAB.tsx`:** FAB exibe `animate-pulse` + box-shadow azul intenso quando há mensagem prioritária. O usuário abre o drawer quando quiser. Ao abrir, `hasPriorityMessage` é zerado.

### Bug 3 — Carregar mensagens da sessão ao montar o ChatDrawer
- **`useChat.ts`:** Novo `useEffect` de montagem que busca `chat_messages` por `session_id` no Supabase, filtrando `sender != 'system'`, ordenando por `created_at asc`. Mescla com `initialMessages` sem duplicatas.

## Cards
- `21ce66ed` — openDrawer UX fix
- `1176c7c8` — histórico de sessão

## Teste
1. Aguardar um system intent com `open_drawer=true` → FAB pulsa, drawer NÃO abre sozinho
2. Abrir drawer manualmente → pulso some, histórico de mensagens anteriores da sessão carrega