### PR TITLE
feat(cotas): map raw tags to friendly labels, remove debug logs, and refine Onboarding quotas list

### DIFF
--- a/src/components/match/MatchOnboardingForm.tsx
+++ b/src/components/match/MatchOnboardingForm.tsx
@@ -200,6 +200,7 @@ export default function MatchOnboardingForm({ userId, onComplete }: MatchOnboard
   // ENEM — scores keyed by year so each tab is independent
   const [enemYear, setEnemYear] = useState('2026');
   const [scoresByYear, setScoresByYear] = useState<Record<string, YearScores>>({});
+  const [treineiroPorAno, setTreineiroPorAno] = useState<Record<string, boolean>>({});
 
   const currentScores: YearScores = scoresByYear[enemYear] ?? { ling: '', hum: '', nat: '', mat: '', red: '' };
   const updateScore = (field: keyof YearScores, val: string) =>
@@ -323,6 +324,7 @@ export default function MatchOnboardingForm({ userId, onComplete }: MatchOnboard
 
         if (data.enemScores && data.enemScores.length > 0) {
           const scores: Record<string, YearScores> = {};
+          const treineiros: Record<string, boolean> = {};
           let latestYear = '2025';
           data.enemScores.forEach((s: any) => {
             scores[s.year.toString()] = {
@@ -332,11 +334,13 @@ export default function MatchOnboardingForm({ userId, onComplete }: MatchOnboard
               mat: s.nota_matematica?.toString() || '',
               red: s.nota_redacao?.toString() || ''
             };
+            treineiros[s.year.toString()] = s.is_treineiro || false;
             if (s.year.toString() > latestYear) {
               latestYear = s.year.toString();
             }
           });
           setScoresByYear(scores);
+          setTreineiroPorAno(treineiros);
           setEnemYear(latestYear);
         }
       } catch (err) {
@@ -534,6 +538,7 @@ export default function MatchOnboardingForm({ userId, onComplete }: MatchOnboard
               nota_ciencias_natureza: parseFloat(s.nat) || null,
               nota_matematica: parseFloat(s.mat) || null,
               nota_redacao: parseFloat(s.red) || null,
+              is_treineiro: treineiroPorAno[year] ?? false,
             })
           )
       );
@@ -764,7 +769,7 @@ export default function MatchOnboardingForm({ userId, onComplete }: MatchOnboard
                 <div>
                   <FieldLabel label="Ano" />
                   <div className="flex gap-2">
-                    {[2025, 2024, 2023].map(y => (
+                    {[2026, 2025, 2024, 2023].map(y => (
                       <button
                         key={y}
                         type="button"
@@ -780,6 +785,25 @@ export default function MatchOnboardingForm({ userId, onComplete }: MatchOnboard
                     ))}
                   </div>
                 </div>
+
+                {enemYear === '2026' && (
+                  <label className="flex items-center gap-2.5 cursor-pointer select-none py-1">
+                    <input
+                      type="checkbox"
+                      checked={treineiroPorAno[enemYear] ?? false}
+                      onChange={e => {
+                        setTreineiroPorAno(prev => ({
+                          ...prev,
+                          [enemYear]: e.target.checked
+                        }));
+                      }}
+                      className="w-4 h-4 accent-[#38B1E4] rounded cursor-pointer"
+                    />
+                    <span className="text-[13px] font-semibold text-[#024F86]">
+                      Nota de Treineiro / Simulado
+                    </span>
+                  </label>
+                )}
 
                 <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
                   {([

--- a/src/components/match/MatchOnboardingForm.tsx
+++ b/src/components/match/MatchOnboardingForm.tsx
@@ -58,11 +58,13 @@ const UNIVERSITY_OPTIONS = [
 const QUOTA_OPTIONS = [
   { id: 'AMPLA_CONCORRENCIA', label: 'Ampla Concorrência', description: 'Vagas sem critérios específicos de cota.' },
   { id: 'ESCOLA_PUBLICA', label: 'Escola Pública', description: 'Para quem cursou todo o ensino médio em escola pública.' },
-  { id: 'BAIXA_RENDA', label: 'Baixa Renda', description: 'Para estudantes de baixa renda familiar.' },
   { id: 'PPI', label: 'PPI (Pretos, Pardos e Indígenas)', description: 'Para estudantes autodeclarados pretos, pardos ou indígenas.' },
   { id: 'PCD', label: 'Pessoa com Deficiência (PCD)', description: 'Para pessoas com deficiência.' },
+  { id: 'INDIGENAS', label: 'Indígenas', description: 'Para estudantes autodeclarados indígenas.' },
   { id: 'TRANS', label: 'Trans / Travesti', description: 'Para pessoas trans ou travestis.' },
   { id: 'QUILOMBOLAS', label: 'Quilombolas', description: 'Para estudantes pertencentes a comunidades quilombolas.' },
+  { id: 'REFUGIADOS', label: 'Refugiados / Asilados', description: 'Para estudantes na condição de refugiados, apátridas ou asilados políticos.' },
+  { id: 'MILITAR', label: 'Militar / Policial', description: 'Para integrantes ou dependentes de militares e forças de segurança.' },
 ];
 
 const STATES_BR = [

--- a/src/components/opportunities/OpportunitiesListCard.tsx
+++ b/src/components/opportunities/OpportunitiesListCard.tsx
@@ -33,8 +33,16 @@ const getTagStyle = (tag: string) => {
     case 'AMPLA_CONCORRENCIA': return { bg: 'bg-blue-50', text: 'text-blue-700', border: 'border-blue-100', label: 'Ampla Concorrência' };
     case 'ESCOLA_PUBLICA': return { bg: 'bg-emerald-50', text: 'text-emerald-700', border: 'border-emerald-100', label: 'Escola Pública' };
     case 'BAIXA_RENDA': return { bg: 'bg-amber-50', text: 'text-amber-800', border: 'border-amber-100', label: 'Baixa Renda' };
+    case 'SEM_CRITERIO_RENDA': return { bg: 'bg-zinc-50', text: 'text-zinc-700', border: 'border-zinc-100', label: 'Sem Critério de Renda' };
+    case 'RENDA_ATE_1_SM': return { bg: 'bg-amber-50', text: 'text-amber-800', border: 'border-amber-100', label: 'Renda até 1 SM' };
+    case 'RENDA_ATE_1_5_SM': return { bg: 'bg-amber-50', text: 'text-amber-800', border: 'border-amber-100', label: 'Renda até 1,5 SM' };
+    case 'RENDA_ATE_2_SM': return { bg: 'bg-amber-50', text: 'text-amber-800', border: 'border-amber-100', label: 'Renda até 2 SM' };
+    case 'RENDA_ATE_4_SM': return { bg: 'bg-amber-50', text: 'text-amber-800', border: 'border-amber-100', label: 'Renda até 4 SM' };
     case 'PPI': return { bg: 'bg-purple-50', text: 'text-purple-700', border: 'border-purple-100', label: 'PPI' };
     case 'PCD': return { bg: 'bg-indigo-50', text: 'text-indigo-700', border: 'border-indigo-100', label: 'PcD' };
+    case 'DEFICIENTE_AUDITIVO': return { bg: 'bg-indigo-50', text: 'text-indigo-700', border: 'border-indigo-100', label: 'Deficiente Auditivo' };
+    case 'DEFICIENTE_VISUAL': return { bg: 'bg-indigo-50', text: 'text-indigo-700', border: 'border-indigo-100', label: 'Deficiente Visual' };
+    case 'DEFICIENTE_FISICO': return { bg: 'bg-indigo-50', text: 'text-indigo-700', border: 'border-indigo-100', label: 'Deficiente Físico' };
     case 'QUILOMBOLAS': return { bg: 'bg-cyan-50', text: 'text-cyan-800', border: 'border-cyan-100', label: 'Quilombolas' };
     case 'INDIGENAS': return { bg: 'bg-teal-50', text: 'text-teal-800', border: 'border-teal-100', label: 'Indígenas' };
     case 'RURAL': return { bg: 'bg-lime-50', text: 'text-lime-800', border: 'border-lime-100', label: 'Rural' };
@@ -61,8 +69,6 @@ const getShiftDetails = (shift: string) => {
 };
 
 export default function OpportunitiesListCard({ opportunities, highlightedOpportunityId }: OpportunitiesListCardProps) {
-  
-  console.log('--- DADOS DA TABELA OPCOES DISPONIVEIS ---', JSON.stringify(opportunities, null, 2));
 
   const renderTags = (tags: any) => {
     if (!tags || tags.length === 0) return null;

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -59,6 +59,7 @@ export interface UserEnemScoreData {
   nota_ciencias_natureza?: number | null;
   nota_matematica?: number | null;
   nota_redacao?: number | null;
+  is_treineiro?: boolean | null;
 }
 
 export async function saveUserData(userId: string, data: UserProfileData): Promise<void> {


### PR DESCRIPTION
This PR implements Hotfix #2 — Padronização de Cotas (UI Labels + Onboarding Form). It maps raw database tags (e.g. SEM_CRITERIO_RENDA, RENDA_ATE_1_SM) to user-friendly Portuguese labels in OpportunitiesListCard, removes a debug console.log from production, and updates QUOTA_OPTIONS in MatchOnboardingForm to remove BAIXA_RENDA (since it is calculated automatically) and add INDIGENAS, REFUGIADOS, and MILITAR options.