### PR TITLE
feat: replace CloudLightning icon with Cloudinha avatar

### DIFF
--- a/src/components/chat/ChatDrawer.tsx
+++ b/src/components/chat/ChatDrawer.tsx
@@ -6,7 +6,8 @@
 //   Desktop: fixed side panel (right, 380px)
 
 import { useEffect, useRef } from 'react';
-import { X, CloudLightning } from 'lucide-react';
+import { X } from 'lucide-react';
+import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 import { motion, AnimatePresence } from 'framer-motion';
 import ChatMessageList from './ChatMessageList';
@@ -133,9 +134,15 @@ export default function ChatDrawer({ onClose, initialMessages = [] }: ChatDrawer
           <div className="flex items-center justify-between px-4 py-3 border-b border-nubo-line/50">
             <div className="flex items-center gap-2.5">
               <div
-                className="flex items-center justify-center w-8 h-8 rounded-xl bg-gradient-to-br from-nubo-primary to-nubo-primary-dark shadow-sm"
+                className="flex items-center justify-center w-8 h-8 rounded-full overflow-hidden shadow-sm"
               >
-                <CloudLightning size={16} color="white" />
+                <Image
+                  src="/assets/cloudinha.jpeg"
+                  alt="Cloudinha"
+                  width={32}
+                  height={32}
+                  className="object-cover w-full h-full"
+                />
               </div>
               <div className="flex flex-col">
                 <p className="text-sm font-bold leading-tight text-nubo-text-head font-sans">

--- a/src/components/chat/ChatFAB.tsx
+++ b/src/components/chat/ChatFAB.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useRef } from 'react';
-import { CloudLightning, X } from 'lucide-react';
+import { X } from 'lucide-react';
+import Image from 'next/image';
 import ChatDrawer from './ChatDrawer';
 import { useSystemIntents } from '@/hooks/useSystemIntents';
 import { useAuth } from '@/contexts/AuthContext';
@@ -77,7 +78,7 @@ export default function ChatFAB() {
       {/* FAB button */}
       <button
         onClick={handleToggle}
-        className="fixed z-30 flex items-center justify-center rounded-full shadow-lg transition-all hover:scale-105 active:scale-95"
+        className="fixed z-30 flex items-center justify-center rounded-full shadow-lg transition-all hover:scale-105 active:scale-95 overflow-hidden"
         style={{
           bottom: 'calc(env(safe-area-inset-bottom) + 112px)',
           right: '16px',
@@ -96,7 +97,13 @@ export default function ChatFAB() {
         {isOpen ? (
           <X size={22} style={{ color: '#38B1E4' }} />
         ) : (
-          <CloudLightning size={22} color="white" />
+          <Image
+            src="/assets/cloudinha.jpeg"
+            alt="Cloudinha"
+            width={52}
+            height={52}
+            className="rounded-full object-cover w-full h-full"
+          />
         )}
 
         {/* Badge de notificação */}


### PR DESCRIPTION
This PR updates ChatFAB.tsx and ChatDrawer.tsx to use the Next.js `<Image />` component with the Cloudinha avatar image (`/assets/cloudinha.jpeg`).

### Changes:
- **ChatFAB.tsx**: Imported `Image` from `next/image` and replaced the generic `CloudLightning` icon with the Cloudinha avatar image. Added `overflow-hidden` class to ensure the button maintains a perfect circular border without image overflow.
- **ChatDrawer.tsx**: Imported `Image` from `next/image` and updated the header container to render the Cloudinha avatar image in a circular shape (`rounded-full overflow-hidden`).
- All TypeScript compilation checks pass successfully.

---
🤖 *Created by Snaps SDLC v4.0*
- **Execution:** `44883811-a836-41e5-8ae7-ce564ffd4b75`
- **Branch:** `feat/cloudinha-icon-avatar`