### PR TITLE
fix(jsonLogic): correção no cálculo de renda per capita e tratamento de caracteres não-numéricos

### DIFF
--- a/src/utils/__tests__/jsonLogic.test.ts
+++ b/src/utils/__tests__/jsonLogic.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateJsonLogic } from '../jsonLogic';
+
+describe('evaluateJsonLogic - Renda & Numeric Parsing', () => {
+  it('deve avaliar corretamente quando a renda é um objeto com per_capita_income', () => {
+    const rule = { '<=': [{ var: 'renda_per_capita' }, 4000] };
+    const dataElegivel = {
+      renda_per_capita: {
+        per_capita_income: 1100,
+        total_income: 4400,
+        family_members: 4,
+      },
+    };
+    const dataNaoElegivel = {
+      renda_per_capita: {
+        per_capita_income: 5000,
+        total_income: 20000,
+        family_members: 4,
+      },
+    };
+
+    expect(evaluateJsonLogic(rule, dataElegivel)).toBe(true);
+    expect(evaluateJsonLogic(rule, dataNaoElegivel)).toBe(false);
+  });
+
+  it('deve ignorar caracteres não numéricos e formatação de moeda em ambas as pontas da comparação', () => {
+    const ruleFormataCriterio = { '<=': [{ var: 'renda' }, 'R$ 4.000,00'] };
+    
+    expect(evaluateJsonLogic(ruleFormataCriterio, { renda: 1100 })).toBe(true);
+    expect(evaluateJsonLogic(ruleFormataCriterio, { renda: 'R$ 1.100,00' })).toBe(true);
+    expect(evaluateJsonLogic(ruleFormataCriterio, { renda: '1.100' })).toBe(true);
+    expect(evaluateJsonLogic(ruleFormataCriterio, { renda: 5000 })).toBe(false);
+    expect(evaluateJsonLogic(ruleFormataCriterio, { renda: 'R$ 5.000,00' })).toBe(false);
+  });
+});

--- a/src/utils/jsonLogic.ts
+++ b/src/utils/jsonLogic.ts
@@ -172,12 +172,57 @@ export function evaluateJsonLogic(rule: unknown, data: Record<string, unknown>):
 
     const evalArgs = (args as unknown[]).map((a) => evaluateJsonLogic(a, data));
 
+function extractNumericValue(val: unknown): number | null {
+  if (val == null) return null;
+  if (typeof val === 'number') return isNaN(val) ? null : val;
+
+  if (typeof val === 'object' && val !== null) {
+    if ('per_capita_income' in val) {
+      return extractNumericValue((val as Record<string, unknown>).per_capita_income);
+    }
+    if ('value' in val) {
+      return extractNumericValue((val as Record<string, unknown>).value);
+    }
+  }
+
+  if (typeof val === 'string') {
+    const trimmed = val.trim();
+    if (trimmed === '') return null;
+
+    if (!isNaN(Number(trimmed))) {
+      return Number(trimmed);
+    }
+
+    if (!/\d/.test(trimmed)) return null;
+
+    let clean = trimmed.replace(/[^\d.,-]/g, '');
+
+    if (clean.includes(',') && clean.indexOf(',') > clean.lastIndexOf('.')) {
+      clean = clean.replace(/\./g, '').replace(',', '.');
+    } else if (clean.includes(',') && !clean.includes('.')) {
+      clean = clean.replace(',', '.');
+    } else if (clean.includes('.') && !clean.includes(',')) {
+      const parts = clean.split('.');
+      if (parts.length > 1 && parts[parts.length - 1].length === 3 && parts[0].length >= 1) {
+        clean = clean.replace(/\./g, '');
+      }
+    } else {
+      clean = clean.replace(/,/g, '');
+    }
+
+    const num = Number(clean);
+    return isNaN(num) ? null : num;
+  }
+
+  return null;
+}
+
     const compare = (a: unknown, b: unknown, opStr: string): boolean => {
         if (a == null || b == null) return false;
-        const numA = Number(a);
-        const numB = Number(b);
-        const valA = isNaN(numA) ? a : numA;
-        const valB = isNaN(numB) ? b : numB;
+        const numA = extractNumericValue(a);
+        const numB = extractNumericValue(b);
+        const valA = numA !== null ? numA : a;
+        const valB = numB !== null ? numB : b;
         switch (opStr) {
             case '>': return (valA as number) > (valB as number);
             case '>=': return (valA as number) >= (valB as number);


### PR DESCRIPTION
## Descrição
- Adicionado helper `extractNumericValue` em `jsonLogic.ts` para desempacotar objetos contendo `per_capita_income`.
- Tratamento de formatação monetária e de caracteres não-numéricos em ambos os lados da comparação.
- Adicionados testes unitários em `src/utils/__tests__/jsonLogic.test.ts` garantindo que o reproducer passe com sucesso.

---
* Created by Snaps SDLC v4.0*
- **Execution:** `96ef0286-36dc-402c-b61a-f385306e3482`
- **Branch:** `feature/sprint-qa-6/feature-1da3abe3`