### PR TITLE
Sprint 16.0: Melhoria nos Carrosséis da Home — Service Layer + Wiring

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,10 +52,11 @@ export default async function HomePage() {
 
   // 1. Buscar seções do CMS
   const sections = await getHomeSections(userState);
+  const isAuthenticated = !!user;
 
   // 2. Se CMS tem seções, buscar dados para cada uma
   if (sections.length > 0) {
-    const sectionsWithData = await populateSections(sections);
+    const sectionsWithData = await populateSections(sections, isAuthenticated);
     return (
       <AppShell>
         <HomeClient sections={sectionsWithData} />
@@ -109,7 +110,10 @@ export default async function HomePage() {
 }
 
 // ─── Helper: popular seções com dados ────────────────────────────────────────
-async function populateSections(sections: IHomeSection[]): Promise<IHomeSectionWithData[]> {
+async function populateSections(
+  sections: IHomeSection[],
+  isAuthenticated: boolean,
+): Promise<IHomeSectionWithData[]> {
   return Promise.all(
     sections.map(async (section): Promise<IHomeSectionWithData> => {
       const limit = (section.config as { limit?: number }).limit ?? 8;
@@ -135,9 +139,11 @@ async function populateSections(sections: IHomeSection[]): Promise<IHomeSectionW
             break;
           }
           case 'match_results': {
+            // config.only_authenticated: seção só faz sentido para usuário logado —
+            // getUnifiedOpportunities({mode:'para-voce'}) cai para resultado genérico
+            // (não personalizado) quando anônimo, então não dá pra confiar só no length.
+            if (!isAuthenticated) break;
             const data = await getUnifiedOpportunities({ mode: 'para-voce', page: 0, limit });
-            // Only keep opportunities with a match score if we want strict matches,
-            // or just use the personalized list. 'para-voce' already sorts by score if user is logged in.
             enriched.opportunities = data;
             break;
           }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,17 +6,17 @@ export const dynamic = 'force-dynamic';
 import AppShell from '@/components/layout/AppShell';
 import HomeClient from './HomeClient';
 import { getHomeSections, type IHomeSection } from '@/services/homeSections';
-import { getUnifiedOpportunities } from '@/services/opportunities';
+import { getUnifiedOpportunities, getFeaturedOpportunities } from '@/services/opportunities';
 import { getImportantDates } from '@/services/importantDates';
-import { getPartnerInstitutions } from '@/services/institutions';
+import { getPartnerInstitutions, getInstitutionsWithOpenOpps } from '@/services/institutions';
 import type { IUnifiedOpportunity } from '@/types/opportunities';
 import type { IImportantDate } from '@/services/importantDates';
-import type { IPartnerInstitution } from '@/services/institutions';
+import type { UnifiedInstitution } from '@/types/institutions';
 
 // Tipo expandido para seções com dados já populados
 export interface IHomeSectionWithData extends IHomeSection {
   opportunities?: IUnifiedOpportunity[];
-  institutions?: IPartnerInstitution[];
+  institutions?: UnifiedInstitution[]; // era IPartnerInstitution[] — ver Peer Review Sprint 16.0 #1
   dates?: IImportantDate[];
 }
 
@@ -64,40 +64,40 @@ export default async function HomePage() {
   }
 
   // 3. FALLBACK — queries hardcoded (backward compat enquanto migration não rodou)
-  const [recentResult, partnersResult, datesResult, institutionsResult] = await Promise.allSettled([
+  const [recentResult, featuredResult, datesResult, institutionsResult] = await Promise.allSettled([
     getUnifiedOpportunities({ mode: 'explorar', page: 0, limit: 8 }),
-    getUnifiedOpportunities({ mode: 'para-voce', page: 0, limit: 8 }),
+    getFeaturedOpportunities(8),
     getImportantDates(),
-    getPartnerInstitutions(),
+    getInstitutionsWithOpenOpps(12),
   ]);
 
   if (recentResult.status === 'rejected')
     console.error('[Home] ERRO recentes:', recentResult.reason);
-  if (partnersResult.status === 'rejected')
-    console.error('[Home] ERRO para-voce:', partnersResult.reason);
+  if (featuredResult.status === 'rejected')
+    console.error('[Home] ERRO em destaque:', featuredResult.reason);
   if (datesResult.status === 'rejected')
     console.error('[Home] ERRO datas:', datesResult.reason);
   if (institutionsResult.status === 'rejected')
     console.error('[Home] ERRO instituições:', institutionsResult.reason);
 
   let recentOpportunities: IUnifiedOpportunity[] = [];
-  let partnerOpportunities: IUnifiedOpportunity[] = [];
+  let featuredOpportunities: IUnifiedOpportunity[] = [];
   let importantDates: IImportantDate[] = [];
-  let partnerInstitutions: IPartnerInstitution[] = [];
+  let featuredInstitutions: UnifiedInstitution[] = [];
 
   if (recentResult.status === 'fulfilled') recentOpportunities = recentResult.value;
-  if (partnersResult.status === 'fulfilled') partnerOpportunities = partnersResult.value.filter((o) => o.is_partner);
+  if (featuredResult.status === 'fulfilled') featuredOpportunities = featuredResult.value;
   if (datesResult.status === 'fulfilled') importantDates = datesResult.value;
-  if (institutionsResult.status === 'fulfilled') partnerInstitutions = institutionsResult.value;
+  if (institutionsResult.status === 'fulfilled') featuredInstitutions = institutionsResult.value;
 
   // Montar seções do fallback para HomeClient consumir no mesmo formato
   const fallbackSections: IHomeSectionWithData[] = [
     { id: 'fb-hero', title: '', section_type: 'hero_search', data_source: 'static', display_order: 0, is_active: true, target_states: null, target_onboarding_status: null, config: {} },
     { id: 'fb-cta', title: '', section_type: 'dynamic_cta', data_source: 'static', display_order: 1, is_active: true, target_states: null, target_onboarding_status: null, config: {} },
     { id: 'fb-match', title: 'Para Você', section_type: 'match_carousel', data_source: 'match_results', display_order: 2, is_active: true, target_states: null, target_onboarding_status: null, config: { only_authenticated: true } },
-    { id: 'fb-partner', title: 'Oportunidades em Destaque', section_type: 'opportunity_carousel', data_source: 'partner_opportunities', display_order: 3, is_active: true, target_states: null, target_onboarding_status: null, config: { see_all_href: '/oportunidades', desktop_grid_mode: true }, opportunities: partnerOpportunities },
+    { id: 'fb-partner', title: 'Oportunidades em Destaque', section_type: 'opportunity_carousel', data_source: 'featured_opportunities', display_order: 3, is_active: true, target_states: null, target_onboarding_status: null, config: { see_all_href: '/oportunidades', desktop_grid_mode: true }, opportunities: featuredOpportunities },
     { id: 'fb-recent', title: 'Novidades', section_type: 'opportunity_carousel', data_source: 'recent_opportunities', display_order: 4, is_active: true, target_states: null, target_onboarding_status: null, config: { see_all_href: '/oportunidades?tab=explore' }, opportunities: recentOpportunities },
-    { id: 'fb-inst', title: 'Instituições Parceiras', section_type: 'institution_carousel', data_source: 'institutions', display_order: 5, is_active: true, target_states: null, target_onboarding_status: null, config: { see_all_href: '/instituicoes' }, institutions: partnerInstitutions },
+    { id: 'fb-inst', title: 'Instituições em Destaque', section_type: 'institution_carousel', data_source: 'institutions_with_open_opps', display_order: 5, is_active: true, target_states: null, target_onboarding_status: null, config: { see_all_href: '/instituicoes' }, institutions: featuredInstitutions },
     { id: 'fb-dates', title: 'Datas Importantes', section_type: 'dates', data_source: 'important_dates', display_order: 6, is_active: true, target_states: null, target_onboarding_status: null, config: {}, dates: importantDates },
   ];
 
@@ -136,9 +136,17 @@ async function populateSections(sections: IHomeSection[]): Promise<IHomeSectionW
           }
           case 'match_results': {
             const data = await getUnifiedOpportunities({ mode: 'para-voce', page: 0, limit });
-            // Only keep opportunities with a match score if we want strict matches, 
+            // Only keep opportunities with a match score if we want strict matches,
             // or just use the personalized list. 'para-voce' already sorts by score if user is logged in.
             enriched.opportunities = data;
+            break;
+          }
+          case 'featured_opportunities': {
+            enriched.opportunities = await getFeaturedOpportunities(limit);
+            break;
+          }
+          case 'institutions_with_open_opps': {
+            enriched.institutions = await getInstitutionsWithOpenOpps(limit);
             break;
           }
           // 'static' não precisa de data fetch server-side

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,9 +30,8 @@ export default async function HomePage() {
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        get(name: string) {
-          return cookieStore.get(name)?.value;
-        },
+        getAll: () => cookieStore.getAll(),
+        setAll: () => {},
       },
     }
   );

--- a/src/services/homeSections.ts
+++ b/src/services/homeSections.ts
@@ -10,7 +10,7 @@ export interface IHomeSection {
   id: string;
   title: string;
   section_type: 'opportunity_carousel' | 'institution_carousel' | 'match_carousel' | 'dates' | 'hero_search' | 'dynamic_cta';
-  data_source: 'partner_opportunities' | 'recent_opportunities' | 'match_results' | 'institutions' | 'important_dates' | 'static';
+  data_source: 'partner_opportunities' | 'recent_opportunities' | 'match_results' | 'institutions' | 'important_dates' | 'static' | 'featured_opportunities' | 'institutions_with_open_opps';
   display_order: number;
   is_active: boolean;
   target_states: string[] | null;

--- a/src/services/institutions.ts
+++ b/src/services/institutions.ts
@@ -52,6 +52,47 @@ export async function getPartnerInstitutions(): Promise<IPartnerInstitution[]> {
   }));
 }
 
+/**
+ * Fetches institutions for the "Instituições em Destaque" Home carousel.
+ * Unified list (partner + MEC), prioritized in 4 tiers:
+ * 1. Partners with open opportunities
+ * 2. MEC with open opportunities
+ * 3. Partners without open opportunities (closed/incoming only)
+ * 4. MEC without open opportunities (closed/incoming only)
+ * Uses has_open_opportunities/is_partner — real boolean columns on
+ * v_unified_institutions (DB-level, ADR-0024) so PostgREST can order
+ * natively without expression ORDER BY.
+ */
+export async function getInstitutionsWithOpenOpps(limit = 12): Promise<UnifiedInstitution[]> {
+  const cookieStore = await cookies();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll: () => cookieStore.getAll(),
+        setAll: () => {},
+      },
+    },
+  );
+
+  const { data, error } = await supabase
+    .from('v_unified_institutions')
+    .select('id, name, location, logo_url, cover_url, brand_color, description, type, is_partner, opp_types, open_opportunities_count, has_open_opportunities')
+    .not('opp_types', 'is', null)
+    .order('has_open_opportunities', { ascending: false })
+    .order('is_partner', { ascending: false })
+    .order('open_opportunities_count', { ascending: false, nullsFirst: false })
+    .order('name', { ascending: true })
+    .limit(limit);
+
+  if (error) {
+    throw new Error(`getInstitutionsWithOpenOpps failed: ${error.message}`);
+  }
+
+  return (data ?? []) as UnifiedInstitution[];
+}
+
 // ─── Unified Institutions (Sprint 8.0) ───────────────────────────────────────
 
 export interface InstitutionsFilters {

--- a/src/services/opportunities.ts
+++ b/src/services/opportunities.ts
@@ -219,6 +219,59 @@ export async function getAvailableCategories(): Promise<string[]> {
   return available;
 }
 
+/**
+ * Fetches featured opportunities for the Home carousel.
+ * Prioritizes: opened first → partners → most recent.
+ * Visible to all users (logged in or not).
+ */
+export async function getFeaturedOpportunities(limit = 8): Promise<IUnifiedOpportunity[]> {
+  const cookieStore = await cookies();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll: () => cookieStore.getAll(),
+        setAll: () => {},
+      },
+      global: {
+        fetch: (url: RequestInfo | URL, init?: RequestInit) => fetch(url, { ...init, cache: 'no-store' }),
+      },
+    },
+  );
+
+  // PostgREST não suporta ORDER BY (expression) DESC nativamente.
+  // Usamos duas queries parciais: primeiro opened, depois o restante.
+  const { data: openedData } = await supabase
+    .from('v_unified_opportunities')
+    .select('*')
+    .eq('status', 'opened')
+    .order('is_partner', { ascending: false })
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  const openedIds = (openedData ?? []).map((r: any) => r.unified_id);
+  const remaining = limit - openedIds.length;
+
+  let restData: any[] = [];
+  if (remaining > 0) {
+    const query = supabase
+      .from('v_unified_opportunities')
+      .select('*')
+      .neq('status', 'opened')
+      .order('is_partner', { ascending: false })
+      .order('created_at', { ascending: false })
+      .limit(remaining);
+
+    const { data } = await query;
+    restData = data ?? [];
+  }
+
+  const allRows = [...(openedData ?? []), ...restData] as UnifiedOpportunityRow[];
+  const mapped = allRows.map(mapRowToOpportunity);
+  return enrichMecOpportunities(mapped, supabase);
+}
+
 export async function getUnifiedOpportunities(
   options: GetUnifiedOpportunitiesOptions,
 ): Promise<IUnifiedOpportunity[]> {

--- a/src/types/institutions.ts
+++ b/src/types/institutions.ts
@@ -15,6 +15,9 @@ export interface UnifiedInstitution {
   type: InstitutionType;
   website_url?: string | null;
   opp_types?: string[] | null;
+  open_opportunities_count?: number;
+  is_partner?: boolean;
+  has_open_opportunities?: boolean;
   acronym?: string | null;
   academic_organization?: string | null;
   administrative_category?: string | null;


### PR DESCRIPTION
## Sprint 16.0 — Carrosséis da Home (Fase 2)

Implementa a camada de serviço e o wiring da Home do plano tático `b98dacfd` (ADR-0023, ADR-0024), já com as correções do Peer Review (`ce1a8fb4`) aplicadas. Depende das migrations em `nubo-educacao/nubo-conecta-admin#27` (deve ser mergeada/aplicada em dev antes deste PR ir para produção).

### O que muda
- **`src/types/institutions.ts`**: `UnifiedInstitution` ganha `open_opportunities_count`, `is_partner`, `has_open_opportunities`.
- **`src/services/homeSections.ts`**: união de `data_source` expandida com `featured_opportunities` e `institutions_with_open_opps`.
- **`src/services/opportunities.ts`**: nova `getFeaturedOpportunities()` — duas queries parciais (opened / not-opened) para contornar a limitação do PostgREST de não ordenar por expressão.
- **`src/services/institutions.ts`**: nova `getInstitutionsWithOpenOpps()` — carrossel unificado "Instituições em Destaque" (parceiras + MEC) em 4 níveis de prioridade: parceira+aberta → mec+aberta → parceira+fechada → mec+fechada. Usa as colunas booleanas reais `is_partner`/`has_open_opportunities` da view (ordenação PostgREST nativa).
- **`src/app/page.tsx`**:
  - **Fix de tipagem (achado #1 do Peer Review)**: `IHomeSectionWithData.institutions` alargado de `IPartnerInstitution[]` para `UnifiedInstitution[]` — `getInstitutionsWithOpenOpps` retorna uma lista unificada, não só parceiras. `InstitutionCarousel` já esperava `UnifiedInstitution[]` nativamente, então isso não quebra nenhum consumidor.
  - Novos `case`s no switch do CMS (`featured_opportunities`, `institutions_with_open_opps`), mantendo os antigos por retrocompat.
  - Bloco de fallback hardcoded atualizado preservando o padrão `Promise.allSettled` (isolamento de falha por fonte).

### Pendente para validação E2E (fora deste PR)
- Seed de dados de dev com oportunidades `incoming`/`closed` (Fase 1.4 do plano) + `REFRESH MATERIALIZED VIEW v_unified_opportunities`, para exercitar os 4 buckets do carrossel de instituições e a priorização "opened first".
- `tsc --noEmit` limpo confirmando o fix de tipagem.

🤖 Gerado pelo Playbook Executor — Execution `56e2eb24-eb67-4642-b7d7-52ade3177190`

---
* Created by Snaps SDLC v4.0*
- **Execution:** `56e2eb24-eb67-4642-b7d7-52ade3177190`
- **Branch:** `feature/sprint-535b5086/feature-b98dacfd`